### PR TITLE
Parameterize the log_timestamp Dovecot configuration setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Example Configuration
         hostname                   => 'mail.example.com',
         lda_mail_plugins           => '$mail_plugins sieve',
         auth_sql_userdb_static     => 'uid=vmail gid=vmail home=/home/vmail/%d/%n',
+        log_timestamp              => '%Y-%m-%d %H:%M:%S ',
     }
     dovecot::file { 'dovecot-sql.conf.ext':
         source => 'puppet:///modules/example/dovecot-sql.conf.ext',

--- a/templates/conf.d/10-logging.conf.erb
+++ b/templates/conf.d/10-logging.conf.erb
@@ -73,6 +73,9 @@ plugin {
 # Prefix for each line written to log file. % codes are in strftime(3)
 # format.
 #log_timestamp = "%b %d %H:%M:%S "
+<% if @log_timestamp -%>
+log_timestamp = <%= @log_timestamp %>
+<% end -%>
 
 # Space-separated list of elements we want to log. The elements which have
 # a non-empty variable value are joined together to form a comma-separated


### PR DESCRIPTION
This PR allows the user to specify a timestamp logging format depending on their needs. An example is also included in the README.
