### PR TITLE
Add log_timestamp parameter support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,6 +21,7 @@ class dovecot (
     $auth_include               = [ 'system' ],
     # 10-logging.conf
     $log_path                   = undef,
+    $log_timestamp              = undef,
     $auth_verbose               = undef,
     $auth_debug                 = undef,
     $mail_debug                 = undef,

--- a/templates/conf.d.orig/10-logging.conf
+++ b/templates/conf.d.orig/10-logging.conf
@@ -61,6 +61,9 @@ plugin {
 # Prefix for each line written to log file. % codes are in strftime(3)
 # format.
 #log_timestamp = "%b %d %H:%M:%S "
+<% if @log_timestamp -%>
+log_timestamp = <%= @log_timestamp %>
+<% end -%> 
 
 # Space-separated list of elements we want to log. The elements which have
 # a non-empty variable value are joined together to form a comma-separated

--- a/templates/conf.d/10-logging.conf.erb
+++ b/templates/conf.d/10-logging.conf.erb
@@ -73,7 +73,9 @@ plugin {
 # Prefix for each line written to log file. % codes are in strftime(3)
 # format.
 #log_timestamp = "%b %d %H:%M:%S "
-
+<% if @log_timestamp -%>
+log_timestamp = <%= @log_timestamp %>
+<% end -%>
 # Space-separated list of elements we want to log. The elements which have
 # a non-empty variable value are joined together to form a comma-separated
 # string.


### PR DESCRIPTION
Allows the user to specify the log_timestamp format for Dovecot
