### PR TITLE
add FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 mxHero Dovecot Puppet Module
 ============================
 
-This module works under RedHat and CentOS 6+ and Ubuntu 12+
+This module works under RedHat, CentOS 6+, Ubuntu 12+ and FreeBSD.
 
 Install, enable and configure the Dovecot IMAP server.
 This module relies heavily on the conf.d structure adopted by dovecot 2.x.

--- a/manifests/file.pp
+++ b/manifests/file.pp
@@ -14,7 +14,12 @@ define dovecot::file (
     $content = undef,
     $source  = undef
 ) {
-    file { "/etc/dovecot/${title}":
+    case $::operatingsystem {
+      'FreeBSD': { $directory = '/usr/local/etc/dovecot' }
+      default:   { $directory = '/etc/dovecot' }
+    }
+
+    file { "${directory}/${title}":
         owner   => $owner,
         group   => $group,
         mode    => $mode,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,13 +102,22 @@ class dovecot (
 
     case $::operatingsystem {
     'RedHat', 'CentOS': { 
-        $packages = 'dovecot'
+        $directory = '/etc/dovecot'
+        $packages  = 'dovecot'
+        $prefix    = 'dovecot'
     } 
     /^(Debian|Ubuntu)$/:{
+        $directory = '/etc/dovecot'
         $packages = ['dovecot-common','dovecot-imapd', 'dovecot-pop3d', 'dovecot-mysql', 'dovecot-lmtpd']
+        $prefix    = 'dovecot'
+    }
+    'FreeBSD': {
+        $directory = '/usr/local/etc/dovecot'
+        $packages  = 'mail/dovecot2'
+        $prefix    = 'mail/dovecot2'
     }
     default: { fail("OS $::operatingsystem and version $::operatingsystemrelease is not supported") }
-}
+    }
 
     # All files in this scope are dovecot configuration files
     File {
@@ -117,7 +126,7 @@ class dovecot (
     }
 
     # Install plugins (sub-packages)
-    dovecot::plugin { $plugins: before => Package[$packages] }
+    dovecot::plugin { $plugins: before => Package[$packages], prefix => $prefix }
 
     # Main package and service it provides
     package { $packages: ensure => installed }
@@ -125,49 +134,57 @@ class dovecot (
         enable    => true,
         ensure    => running,
         hasstatus => true,
-        require   => File['/etc/dovecot/dovecot.conf'],
+        require   => File["${directory}/dovecot.conf"],
+    }
+
+    # Main configuration directory
+    file { "${directory}":
+        ensure => 'directory',
+    }
+    file { "${directory}/conf.d":
+        ensure => 'directory',
     }
 
     # Main configuration file
-    file { '/etc/dovecot/dovecot.conf':
+    file { "${directory}/dovecot.conf":
         content => template('dovecot/dovecot.conf.erb'),
     }
 
     # Configuration file snippets which we modify
-    file { '/etc/dovecot/conf.d/10-auth.conf':
+    file { "${directory}/conf.d/10-auth.conf":
         content => template('dovecot/conf.d/10-auth.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/10-logging.conf':
+    file { "${directory}/conf.d/10-logging.conf":
         content => template('dovecot/conf.d/10-logging.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/10-mail.conf':
+    file { "${directory}/conf.d/10-mail.conf":
         content => template('dovecot/conf.d/10-mail.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/10-master.conf':
+    file { "${directory}/conf.d/10-master.conf":
         content => template('dovecot/conf.d/10-master.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/10-ssl.conf':
+    file { "${directory}/conf.d/10-ssl.conf":
         content => template('dovecot/conf.d/10-ssl.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/20-imap.conf':
+    file { "${directory}/conf.d/20-imap.conf":
         content => template('dovecot/conf.d/20-imap.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/20-pop3.conf':
+    file { "${directory}/conf.d/20-pop3.conf":
         content => template('dovecot/conf.d/20-pop3.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/15-lda.conf':
+    file { "${directory}/conf.d/15-lda.conf":
         content => template('dovecot/conf.d/15-lda.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/90-sieve.conf':
+    file { "${directory}/conf.d/90-sieve.conf":
         content => template('dovecot/conf.d/90-sieve.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/90-quota.conf':
+    file { "${directory}/conf.d/90-quota.conf":
         content => template('dovecot/conf.d/90-quota.conf.erb'),
     }
-    file { '/etc/dovecot/conf.d/auth-passwdfile.conf.ext' :
+    file { "${directory}/conf.d/auth-passwdfile.conf.ext" :
         content => template('dovecot/conf.d/auth-passwdfile.conf.ext.erb'),
     }
-    file { '/etc/dovecot/conf.d/auth-sql.conf.ext' :
+    file { "${directory}/conf.d/auth-sql.conf.ext" :
         content => template('dovecot/conf.d/auth-sql.conf.ext.erb'),
     }
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -6,7 +6,7 @@
 # Example Usage:
 #     class { 'dovecot': plugins => [ 'mysql', 'pigeonhole' ] }
 #
-define dovecot::plugin() {
-    package { "dovecot-${title}": ensure => installed }
+define dovecot::plugin( $prefix = 'dovecot' ) {
+    package { "${prefix}-${title}": ensure => installed }
 }
 

--- a/templates/conf.d/auth-deny.conf.ext.erb
+++ b/templates/conf.d/auth-deny.conf.ext.erb
@@ -11,5 +11,5 @@ passdb {
   deny = yes
 
   # File contains a list of usernames, one per line
-  args = /etc/dovecot/deny-users
+  args = <%= @directory %>/deny-users
 }

--- a/templates/conf.d/auth-ldap.conf.ext.erb
+++ b/templates/conf.d/auth-ldap.conf.ext.erb
@@ -6,7 +6,7 @@ passdb {
   driver = ldap
 
   # Path for LDAP configuration file, see example-config/dovecot-ldap.conf.ext
-  args = /etc/dovecot/dovecot-ldap.conf.ext
+  args = <%= @directory %>/dovecot-ldap.conf.ext
 }
 
 # "prefetch" user database means that the passdb already provided the
@@ -18,7 +18,7 @@ passdb {
 
 userdb {
   driver = ldap
-  args = /etc/dovecot/dovecot-ldap.conf.ext
+  args = <%= @directory %>/dovecot-ldap.conf.ext
 }
 
 # If you don't have any user-specific settings, you can avoid the userdb LDAP

--- a/templates/conf.d/auth-master.conf.ext.erb
+++ b/templates/conf.d/auth-master.conf.ext.erb
@@ -8,7 +8,7 @@
 passdb {
   driver = passwd-file
   master = yes
-  args = /etc/dovecot/master-users
+  args = <%= @directory %>/master-users
 
   # Unless you're using PAM, you probably still want the destination user to
   # be looked up from passdb that it really exists. pass=yes does that.

--- a/templates/conf.d/auth-passwdfile.conf.ext.erb
+++ b/templates/conf.d/auth-passwdfile.conf.ext.erb
@@ -8,7 +8,7 @@ passdb {
   <% if @auth_passwdfile_passdb -%>
   args = <%= @auth_passwdfile_passdb %>
   <% else %>
-  args = scheme=CRYPT username_format=%u /etc/dovecot/users
+  args = scheme=CRYPT username_format=%u <%= @directory %>/users
   <% end -%>
 }
 
@@ -17,6 +17,6 @@ userdb {
   <% if @auth_passwdfile_userdb -%>
   args = <%= @auth_passwdfile_userdb %>
   <% else %>
-  args = username_format=%u /etc/dovecot/users
+  args = username_format=%u <%= @directory %>/users
   <% end -%>
 }


### PR DESCRIPTION
Addresses two differences to add support for FreeBSD:
- different dovecot directory (/usr/local/etc/dovecot)
- different package name format (category/package)
