### PR TITLE
Added include_inbox_namespace to specify inbox namespace

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,8 @@ class dovecot (
     $mail_privileged_group      = undef,
     $mail_plugins               = undef,
     $mmap_disable               = undef,
-    $dotlock_use_excl           = undef, 
+    $dotlock_use_excl           = undef,
+    $include_inbox_namespace	= undef,
     # 10-master.conf
     $default_process_limit      = undef,
     $default_client_limit       = undef,

--- a/templates/conf.d/10-mail.conf.erb
+++ b/templates/conf.d/10-mail.conf.erb
@@ -32,6 +32,13 @@
 mail_location = <%= @mail_location %>
 <% end -%>
 
+
+<% if @include_inbox_namespace -%>
+namespace inbox {
+  inbox = yes
+}
+<% end -%>
+
 # If you need to set multiple mailbox locations or want to change default
 # namespace settings, you can do it by defining namespace sections.
 #


### PR DESCRIPTION
For some reason, dovecot insists on having a namespace with "inbox=yes".
I implemented this as simply as possible :-)

My resulting 10-mail.conf
 cat /etc/dovecot/conf.d/10-mail.conf | grep -v ^".*#" | grep -v ^$ 
mail_location = mbox:~/mail/mailboxes:DIRNAME=mbox:INDEX=~/mail/index:CONTROL=~/mail/control
namespace inbox {
  inbox = yes
}
mbox_write_locks = fcntl

If you want it implemented differently, do tell, and I will try to accommodate you.
