### PR TITLE
fts support, managesieve support, support for mail_uid/mail_gid

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,7 +93,7 @@ class dovecot (
     $sieve_quota_max_scripts    = undef,
     $sieve_quota_max_storage    = undef,
     # 90-plugin.conf
-    $fts_lucene                 = undef,
+    $fts                        = undef,
     # 90-quota.conf
     $quota                      = undef,
     $quota_warnings             = [],
@@ -154,6 +154,7 @@ class dovecot (
         ensure    => running,
         hasstatus => true,
         require   => File["${directory}/dovecot.conf"],
+      }
     }
 
     # Main configuration directory

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,8 @@ class dovecot (
     # 10-mail.conf
     $mail_fsync                 = undef,
     $mail_location              = undef,
+    $mail_uid                   = undef,
+    $mail_gid                   = undef,
     $mail_nfs_index             = undef,
     $mail_nfs_storage           = undef,
     $mail_privileged_group      = undef,
@@ -90,6 +92,8 @@ class dovecot (
     $sieve_max_script_size      = undef,
     $sieve_quota_max_scripts    = undef,
     $sieve_quota_max_storage    = undef,
+    # 90-plugin.conf
+    $fts_lucene                 = undef,
     # 90-quota.conf
     $quota                      = undef,
     $quota_warnings             = [],
@@ -190,6 +194,9 @@ class dovecot (
     file { "${directory}/conf.d/20-pop3.conf":
         content => template('dovecot/conf.d/20-pop3.conf.erb'),
     }
+    file { "${directory}/conf.d/20-managesieve.conf":
+        content => template('dovecot/conf.d/20-managesieve.conf.erb'),
+    }
     file { "${directory}/conf.d/15-lda.conf":
         content => template('dovecot/conf.d/15-lda.conf.erb'),
     }
@@ -198,6 +205,9 @@ class dovecot (
     }
     file { "${directory}/conf.d/90-quota.conf":
         content => template('dovecot/conf.d/90-quota.conf.erb'),
+    }
+    file { "${directory}/conf.d/90-plugin.conf":
+        content => template('dovecot/conf.d/90-plugin.conf.erb'),
     }
     file { "${directory}/conf.d/auth-passwdfile.conf.ext" :
         content => template('dovecot/conf.d/auth-passwdfile.conf.ext.erb'),

--- a/templates/conf.d/10-mail.conf.erb
+++ b/templates/conf.d/10-mail.conf.erb
@@ -117,7 +117,13 @@ namespace inbox {
 # can override these by returning uid or gid fields. You can use either numbers
 # or names. <doc/wiki/UserIds.txt>
 #mail_uid =
+<% if @mail_uid -%>
+mail_uid = <%= @mail_uid %>
+<% end -%>
 #mail_gid =
+<% if @mail_gid -%>
+mail_gid = <%= @mail_gid %>
+<% end -%>
 
 # Group to enable temporarily for privileged operations. Currently this is
 # used only with INBOX when either its initial creation or dotlocking fails.

--- a/templates/conf.d/90-plugin.conf.erb
+++ b/templates/conf.d/90-plugin.conf.erb
@@ -8,4 +8,8 @@
 
 plugin {
   #setting_name = value
+<% if @fts_lucene -%>
+  fts = lucene
+  fts_lucene = whitespace_chars=@.
+<% end -%>
 }

--- a/templates/conf.d/90-plugin.conf.erb
+++ b/templates/conf.d/90-plugin.conf.erb
@@ -8,8 +8,13 @@
 
 plugin {
   #setting_name = value
-<% if @fts_lucene -%>
-  fts = lucene
+<% if @fts -%>
+  fts = <%= @fts.join(' ') %>
+<% if @fts.include? 'squat' -%>
+  fts_squat = partial=4 full=10
+<% end -%>
+<% if @fts.include? 'lucene' -%>
   fts_lucene = whitespace_chars=@.
+<% end -%>
 <% end -%>
 }


### PR DESCRIPTION
This pull request adds multiple optional parameters and functions:
* full text search with lucene or squat using sensible defaults from dovecot.org
* deploying 20-managesieve.conf by default to support plugin managesieved if specified 
* ability to change mail_uid and mail_gid

Also:
* fix small bux in init.pp introduced by commit e222756