### PR TITLE
Options for logjam exploit

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,7 @@ class dovecot (
 
     $manage_service              = true,
     $custom_packages             = undef,
+    $ensure_packages             = 'installed',
 ) {
 
     if $custom_packages == undef {
@@ -172,7 +173,7 @@ class dovecot (
     dovecot::plugin { $plugins: before => Package[$packages], prefix => $prefix }
 
     # Main package and service it provides
-    package { $packages: ensure => installed }
+    package { $packages: ensure => $ensure_packages }
     if $manage_service {
       service { 'dovecot':
         enable    => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,6 +67,7 @@ class dovecot (
     $ssl_key                    = '/etc/pki/dovecot/private/dovecot.pem',
     $ssl_cipher_list            = undef,
     $ssl_protocols              = undef,
+    $ssl_dh_parameters_length   = undef,
     # 15-lda.conf
     $postmaster_address         = undef,
     $hostname                   = undef,

--- a/templates/conf.d/10-ssl.conf.erb
+++ b/templates/conf.d/10-ssl.conf.erb
@@ -42,6 +42,11 @@ ssl_key = <<%= @ssl_key %>
 # entirely.
 #ssl_parameters_regenerate = 168
 
+# dovecot 2.2.7+, you can set the bit length of DHE
+<% if @ssl_dh_parameters_length -%>
+ssl_dh_parameters_length = <%= @ssl_dh_parameters_length -%>
+<% end -%>
+
 # SSL ciphers to use
 #ssl_cipher_list = ALL:!LOW:!SSLv2:!EXP:!aNULL
 <% if @ssl_cipher_list -%>


### PR DESCRIPTION
the new (dovecot 2.2.7+) ssl_dh_parameters_length allow to set the ephemeral diffie-hellman key length