### PR TITLE
Fix deprecated variable reference

### DIFF
--- a/templates/conf.d/20-imap.conf.erb
+++ b/templates/conf.d/20-imap.conf.erb
@@ -3,9 +3,9 @@
 ##
 
 protocol imap {
-  listen = <%= imap_listen_port %>
+  listen = <%= @imap_listen_port %>
   <% if @ssl =~ /yes/ %>
-  ssl_listen = <%= imaps_listen_port %>
+  ssl_listen = <%= @imaps_listen_port %>
   <% end %>
   
   # Maximum IMAP command line length. Some clients generate very long command


### PR DESCRIPTION
This currently causes an error message like 

```
==> default: Warning: Variable access via 'imap_listen_port' is deprecated. Use '@imap_listen_port' instead. template[/tmp/vagrant-puppet/environments/production/modules/dovecot/templates/conf.d/20-imap.conf.erb]:6
==> default:    (at /usr/lib/ruby/vendor_ruby/puppet/parser/templatewrapper.rb:76:in `method_missing')
```

and will even fail the Puppet run on Puppet 4.