### PR TITLE
Disable_plaintext_auth needs to be set

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class dovecot (
     $verbose_proctitle          = undef,
     $shutdown_clients           = undef,
     # 10-auth.conf
-    $disable_plaintext_auth     = undef,
+    $disable_plaintext_auth     = true,
     $auth_username_chars        = undef,
     $auth_mechanisms            = 'plain',
     $auth_include               = [ 'system' ],


### PR DESCRIPTION
`validate_bool($disabe_plaintext_auth)` will fail if
`$disable_plaintext_auth` is `undef` due to a type mismatch.

Setting it to the default value as per the configuration doesn't hurt.