### PR TITLE
lmtp_save_to_detail_mailbox needs to be set

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,7 +89,7 @@ class dovecot (
     $imap_client_workarounds    = undef,
     # 20-lmtp.conf
     $lmtp_mail_plugins          = undef,
-    $lmtp_save_to_detail_mailbox = undef,
+    $lmtp_save_to_detail_mailbox = false,
     # 20-pop3.conf
     $pop3_mail_plugins          = undef,
     $pop3_uidl_format           = undef,


### PR DESCRIPTION
validate_bool($lmtp_save_to_detail_mailbox) will fail if
$lmtp_save_to_detail_mailbox is undef due to a type mismatch.

Setting it to the default value as per the configuration doesn't hurt.